### PR TITLE
add new features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ video-editing/
 video-editing/**/**
 testing-all-nodes-megaworkflow.json
 todo.md
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -2,6 +2,21 @@
 
 https://github.com/user-attachments/assets/c5cf20de-a17f-438d-81ac-0c392af669cf
 
+## New Nodes
+
+The following nodes are included to make building and managing audio lists easier:
+
+- AudioSplitEqual: Split a single `AUDIO` into N equal segments and output up to 8 separate `AUDIO` outputs. Useful for simple, fixed-fan-out splitting.
+- AudioSplitEqualList: Split a single `AUDIO` into N equal segments and return an `AUDIO_LIST`. Best for workflows that prefer list-driven processing.
+- AudioListGet: Retrieve an item from an `AUDIO_LIST` by index. Supports out-of-range modes: `error` (raise), `clamp` (to 0 or len-1), `wrap` (modulo length).
+- AudioStitch: Concatenate an `AUDIO_LIST` end-to-end into a single `AUDIO`. Optionally force stereo to avoid channel mismatches.
+- AudioNewList: Create a new `AUDIO_LIST` from multiple `AUDIO` inputs in the exact order connected. Includes an `inputcount` control and an “Update inputs” button to dynamically add/remove `audio_N` input sockets. `ignore_empty=True` skips unconnected sockets; set to `False` to enforce all inputs.
+
+Tips
+- After changing `inputcount` on AudioNewList, click “Update inputs” to apply the new number of inputs.
+- If you add or update this node package, restart ComfyUI and hard-refresh your browser to ensure the UI extension loads.
+
+
 # Examples
 
 #### _`Separating Voices in a Video`_

--- a/__init__.py
+++ b/__init__.py
@@ -5,6 +5,9 @@ from .src.combine import AudioCombine
 from .src.combine_video_with_audio import AudioVideoCombine
 from .src.time_shift import TimeShift
 from .src.get_tempo import GetTempo
+from .src.split_equal import AudioSplitEqual, AudioSplitEqualList
+from .src.list_get import AudioListGet
+from .src.stitch import AudioStitch
 
 
 NODE_CLASS_MAPPINGS = {
@@ -15,4 +18,8 @@ NODE_CLASS_MAPPINGS = {
     "AudioVideoCombine": AudioVideoCombine,
     "AudioSpeedShift": TimeShift,
     "AudioGetTempo": GetTempo,
+    "AudioSplitEqual": AudioSplitEqual,
+    "AudioSplitEqualList": AudioSplitEqualList,
+    "AudioListGet": AudioListGet,
+    "AudioStitch": AudioStitch,
 }

--- a/__init__.py
+++ b/__init__.py
@@ -8,6 +8,7 @@ from .src.get_tempo import GetTempo
 from .src.split_equal import AudioSplitEqual, AudioSplitEqualList
 from .src.list_get import AudioListGet
 from .src.stitch import AudioStitch
+from .src.audio_new_list import AudioNewList
 
 
 NODE_CLASS_MAPPINGS = {
@@ -22,4 +23,8 @@ NODE_CLASS_MAPPINGS = {
     "AudioSplitEqualList": AudioSplitEqualList,
     "AudioListGet": AudioListGet,
     "AudioStitch": AudioStitch,
+    "AudioNewList": AudioNewList,
 }
+
+# Expose frontend extensions (JS) from the ./web directory
+WEB_DIRECTORY = "./web"

--- a/src/audio_new_list.py
+++ b/src/audio_new_list.py
@@ -1,0 +1,61 @@
+from typing import List, Tuple, Optional, Any
+
+from ._types import AUDIO
+
+
+class AudioNewList:
+    @classmethod
+    def INPUT_TYPES(cls):
+        # Two required audio inputs and a dynamic input count controller.
+        return {
+            "required": {
+                "inputcount": ("INT", {"default": 2, "min": 2, "max": 1000, "step": 1, "tooltip": "Number of AUDIO inputs to expose. Click 'Update inputs' to apply."}),
+                "audio_1": ("AUDIO",),
+                "audio_2": ("AUDIO",),
+            },
+            "optional": {
+                "ignore_empty": (
+                    "BOOLEAN",
+                    {
+                        "default": True,
+                        "tooltip": "If True, skip unconnected inputs. If False, raise if any requested input is missing.",
+                    },
+                )
+            },
+        }
+
+    FUNCTION = "main"
+    RETURN_TYPES = ("AUDIO_LIST",)
+    RETURN_NAMES = ("List",)
+    CATEGORY = "audio"
+    DESCRIPTION = "Create a new AUDIO_LIST from multiple AUDIO inputs in the provided order. Use inputcount + Update inputs to adjust ports."
+
+    def main(
+        self,
+        inputcount: int,
+        ignore_empty: bool = True,
+        **kwargs: Any,
+    ) -> Tuple[List[AUDIO]]:
+        # Clamp to sensible bounds
+        try:
+            n = int(inputcount)
+        except Exception:
+            n = 2
+        n = max(2, min(1000, n))
+
+        # Collect in order: audio_1 .. audio_n
+        out: List[AUDIO] = []
+
+        for idx in range(1, n + 1):
+            key = f"audio_{idx}"
+            val = kwargs.get(key)
+            if val is None:
+                if ignore_empty:
+                    continue
+                raise ValueError(f"AudioNewList: Missing required input '{key}' while 'ignore_empty' is False.")
+            out.append(val)
+
+        if len(out) < 2:
+            raise ValueError("AudioNewList: Need at least two AUDIO inputs to form a list.")
+
+        return (out,)

--- a/src/list_get.py
+++ b/src/list_get.py
@@ -1,0 +1,55 @@
+from typing import Tuple, List, Any
+
+
+class AudioListGet:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "audio_list": ("AUDIO_LIST",),
+                "index": (
+                    "INT",
+                    {
+                        "default": 0,
+                        "min": 0,
+                        "max": 10_000,
+                        "step": 1,
+                        "tooltip": "Zero-based index into the audio list.",
+                    },
+                ),
+            },
+            "optional": {
+                "out_of_range": (
+                    ["error", "clamp", "wrap"],
+                    {
+                        "default": "clamp",
+                        "tooltip": "Behavior when index is out of range: error, clamp to range, or wrap modulo length.",
+                    },
+                ),
+            },
+        }
+
+    FUNCTION = "main"
+    RETURN_TYPES = ("AUDIO", "INT")
+    RETURN_NAMES = ("Audio", "Length")
+    CATEGORY = "audio"
+    DESCRIPTION = "Get a single AUDIO from an AUDIO_LIST by index."
+
+    def main(self, audio_list: List[Any], index: int = 0, out_of_range: str = "clamp") -> Tuple[Any, int]:
+        if not isinstance(audio_list, list):
+            raise TypeError("AudioListGet: 'audio_list' must be a list.")
+        if len(audio_list) == 0:
+            raise ValueError("AudioListGet: 'audio_list' is empty.")
+
+        n = len(audio_list)
+        i = int(index)
+
+        if i < 0 or i >= n:
+            if out_of_range == "error":
+                raise IndexError(f"AudioListGet: index {i} out of range [0, {n-1}].")
+            elif out_of_range == "wrap":
+                i = i % n
+            else:  # clamp
+                i = 0 if i < 0 else n - 1
+
+        return (audio_list[i], n)

--- a/src/split_equal.py
+++ b/src/split_equal.py
@@ -1,0 +1,133 @@
+import torch
+
+from typing import Tuple, List
+from ._types import AUDIO
+
+
+class AudioSplitEqual:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "audio": ("AUDIO",),
+            },
+            "optional": {
+                "segments": (
+                    "INT",
+                    {
+                        "default": 2,
+                        "min": 1,
+                        "max": 8,
+                        "step": 1,
+                        "tooltip": "Number of equal segments to split the audio into (1-8).",
+                    },
+                )
+            },
+        }
+
+    FUNCTION = "main"
+    # Fixed maximum outputs; unused outputs will be None
+    RETURN_TYPES = ("AUDIO", "AUDIO", "AUDIO", "AUDIO", "AUDIO", "AUDIO", "AUDIO", "AUDIO")
+    RETURN_NAMES = (
+        "Segment 1",
+        "Segment 2",
+        "Segment 3",
+        "Segment 4",
+        "Segment 5",
+        "Segment 6",
+        "Segment 7",
+        "Segment 8",
+    )
+    CATEGORY = "audio"
+    DESCRIPTION = "Split an audio clip into N equal segments and output up to 8 segments."
+
+    def main(self, audio: AUDIO, segments: int = 2) -> Tuple[AUDIO, ...]:
+        waveform: torch.Tensor = audio["waveform"]
+        sample_rate: int = audio["sample_rate"]
+
+        # Normalize and clamp segments
+        try:
+            n = int(segments)
+        except Exception:
+            n = 2
+        n = max(1, min(8, n))
+
+        total_frames = waveform.shape[-1]
+        base = total_frames // n
+        rem = total_frames % n
+
+        # Distribute remainder: first `rem` segments get one extra frame
+        sizes: List[int] = [(base + 1 if i < rem else base) for i in range(n)]
+
+        # Create cumulative indices for slicing
+        indices = [0]
+        for s in sizes:
+            indices.append(indices[-1] + s)
+
+        outputs: List[AUDIO] = []
+        for i in range(n):
+            start, end = indices[i], indices[i + 1]
+            seg_waveform = waveform[..., start:end]
+            outputs.append({"waveform": seg_waveform, "sample_rate": sample_rate})
+
+        # Pad remaining outputs with None to satisfy fixed RETURN_TYPES
+        while len(outputs) < 8:
+            outputs.append(None)
+
+        return tuple(outputs)
+
+
+class AudioSplitEqualList:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "audio": ("AUDIO",),
+            },
+            "optional": {
+                "segments": (
+                    "INT",
+                    {
+                        "default": 2,
+                        "min": 1,
+                        "max": 64,
+                        "step": 1,
+                        "tooltip": "Number of equal segments to split the audio into (1-64).",
+                    },
+                )
+            },
+        }
+
+    FUNCTION = "main"
+    RETURN_TYPES = ("AUDIO_LIST",)
+    RETURN_NAMES = ("Segments",)
+    CATEGORY = "audio"
+    DESCRIPTION = "Split an audio clip into N equal segments and return a list of AUDIO objects."
+
+    def main(self, audio: AUDIO, segments: int = 2):
+        waveform: torch.Tensor = audio["waveform"]
+        sample_rate: int = audio["sample_rate"]
+
+        try:
+            n = int(segments)
+        except Exception:
+            n = 2
+        n = max(1, min(64, n))
+
+        total_frames = waveform.shape[-1]
+        base = total_frames // n
+        rem = total_frames % n
+
+        sizes = [(base + 1 if i < rem else base) for i in range(n)]
+
+        indices = [0]
+        for s in sizes:
+            indices.append(indices[-1] + s)
+
+        outputs = []
+        for i in range(n):
+            start, end = indices[i], indices[i + 1]
+            seg_waveform = waveform[..., start:end]
+            outputs.append({"waveform": seg_waveform, "sample_rate": sample_rate})
+
+        return (outputs,)

--- a/src/stitch.py
+++ b/src/stitch.py
@@ -1,0 +1,69 @@
+import torch
+from typing import List, Tuple, Any
+
+from ._types import AUDIO
+from .utils import ensure_stereo
+
+
+class AudioStitch:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "audio_list": ("AUDIO_LIST",),
+            },
+            "optional": {
+                "force_stereo": (
+                    "BOOLEAN",
+                    {
+                        "default": True,
+                        "tooltip": "If True, convert all clips to stereo before stitching to avoid channel mismatches.",
+                    },
+                ),
+            },
+        }
+
+    FUNCTION = "main"
+    RETURN_TYPES = ("AUDIO",)
+    RETURN_NAMES = ("Audio",)
+    CATEGORY = "audio"
+    DESCRIPTION = "Concatenate a list of AUDIO clips into a single longer clip."
+
+    def main(self, audio_list: List[AUDIO], force_stereo: bool = True) -> Tuple[AUDIO]:
+        if not isinstance(audio_list, list) or len(audio_list) == 0:
+            raise ValueError("AudioStitch: 'audio_list' must be a non-empty list.")
+
+        # Validate sample rates and dimensions
+        sample_rate = audio_list[0]["sample_rate"]
+        first_wave = audio_list[0]["waveform"]
+        if not isinstance(first_wave, torch.Tensor):
+            raise TypeError("AudioStitch: waveform must be a torch.Tensor.")
+        ndims = first_wave.ndim
+
+        processed: List[torch.Tensor] = []
+        for idx, a in enumerate(audio_list):
+            if a["sample_rate"] != sample_rate:
+                raise ValueError(
+                    f"AudioStitch: sample_rate mismatch at index {idx}: {a['sample_rate']} != {sample_rate}"
+                )
+            w = a["waveform"]
+            if w.ndim != ndims:
+                raise ValueError(
+                    f"AudioStitch: waveform dim mismatch at index {idx}: {w.ndim} != {ndims}"
+                )
+            if force_stereo:
+                w = ensure_stereo(w)
+            processed.append(w)
+
+        # Confirm channel count alignment
+        channels = [t.shape[-2] if t.ndim >= 2 else 1 for t in processed]
+        if len(set(channels)) != 1:
+            raise ValueError(
+                f"AudioStitch: channel count mismatch after processing: {channels}. Disable 'force_stereo' only if all match."
+            )
+
+        # Concatenate along time dimension (last axis)
+        stitched = torch.cat(processed, dim=-1)
+
+        return ({"waveform": stitched, "sample_rate": sample_rate},)
+

--- a/web/js/jsnodes.js
+++ b/web/js/jsnodes.js
@@ -1,0 +1,41 @@
+import { app } from "../../../scripts/app.js";
+
+app.registerExtension({
+  name: "AudioSeparationNodes.AudioNewList.DynamicInputs",
+  async beforeRegisterNodeDef(nodeType, nodeData, app) {
+    if (nodeData?.name !== "AudioNewList") return;
+
+    const onNodeCreated = nodeType.prototype.onNodeCreated;
+    nodeType.prototype.onNodeCreated = function () {
+      const r = onNodeCreated ? onNodeCreated.apply(this, arguments) : undefined;
+
+      this._type = "AUDIO";
+      this.inputs_offset = 0;
+      this.addWidget("button", "Update inputs", null, () => {
+        if (!this.inputs) this.inputs = [];
+
+        const widget = this.widgets?.find((w) => w.name === "inputcount");
+        const target_number_of_inputs = widget ? widget.value : 2;
+        const num_inputs = this.inputs.filter((input) => input.type === this._type).length;
+
+        if (target_number_of_inputs === num_inputs) return; // already set
+
+        if (target_number_of_inputs < num_inputs) {
+          // Remove only trailing AUDIO inputs beyond the target
+          for (let i = this.inputs.length - 1; i >= 0; i--) {
+            if (this.inputs.filter((input) => input.type === this._type).length <= target_number_of_inputs) break;
+            if (this.inputs[i].type === this._type) {
+              this.removeInput(i);
+            }
+          }
+        } else {
+          for (let i = num_inputs + 1; i <= target_number_of_inputs; ++i) {
+            this.addInput(`audio_${i}`, this._type);
+          }
+        }
+      });
+
+      return r;
+    };
+  },
+});


### PR DESCRIPTION
## New Nodes

The following nodes are included to make building and managing audio lists easier:

- AudioSplitEqual: Split a single `AUDIO` into N equal segments and output up to 8 separate `AUDIO` outputs. Useful for simple, fixed-fan-out splitting.
- AudioSplitEqualList: Split a single `AUDIO` into N equal segments and return an `AUDIO_LIST`. Best for workflows that prefer list-driven processing.
- AudioListGet: Retrieve an item from an `AUDIO_LIST` by index. Supports out-of-range modes: `error` (raise), `clamp` (to 0 or len-1), `wrap` (modulo length).
- AudioStitch: Concatenate an `AUDIO_LIST` end-to-end into a single `AUDIO`. Optionally force stereo to avoid channel mismatches.
- AudioNewList: Create a new `AUDIO_LIST` from multiple `AUDIO` inputs in the exact order connected. Includes an `inputcount` control and an “Update inputs” button to dynamically add/remove `audio_N` input sockets. `ignore_empty=True` skips unconnected sockets; set to `False` to enforce all inputs.