### PR TITLE
Add VIDEO-aware AudioVideoCombine and CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,63 @@
+name: Tests
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    strategy:
+        matrix:
+          python-version: ["3.9", "3.10", "3.11"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install tooling
+        working-directory: custom_nodes/audio-separation-nodes-comfyui
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e '.[test,dev]'
+      - name: Ruff format check
+        working-directory: custom_nodes/audio-separation-nodes-comfyui
+        run: ruff format --check src tests
+      - name: Ruff lint
+        working-directory: custom_nodes/audio-separation-nodes-comfyui
+        run: ruff check src tests
+      - name: Python bytecode compile
+        working-directory: custom_nodes/audio-separation-nodes-comfyui
+        run: python -m compileall src
+      - name: Run tests
+        working-directory: custom_nodes/audio-separation-nodes-comfyui
+        run: pytest tests
+
+  windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install tooling
+        working-directory: custom_nodes/audio-separation-nodes-comfyui
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[test,dev]"
+      - name: Ruff format check
+        working-directory: custom_nodes/audio-separation-nodes-comfyui
+        run: ruff format --check src tests
+      - name: Ruff lint
+        working-directory: custom_nodes/audio-separation-nodes-comfyui
+        run: ruff check src tests
+      - name: Python bytecode compile
+        working-directory: custom_nodes/audio-separation-nodes-comfyui
+        run: python -m compileall src
+      - name: Run tests
+        working-directory: custom_nodes/audio-separation-nodes-comfyui
+        run: pytest tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,21 +17,16 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install tooling
-        working-directory: custom_nodes/audio-separation-nodes-comfyui
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e '.[test,dev]'
       - name: Ruff format check
-        working-directory: custom_nodes/audio-separation-nodes-comfyui
         run: ruff format --check src tests
       - name: Ruff lint
-        working-directory: custom_nodes/audio-separation-nodes-comfyui
         run: ruff check src tests
       - name: Python bytecode compile
-        working-directory: custom_nodes/audio-separation-nodes-comfyui
         run: python -m compileall src
       - name: Run tests
-        working-directory: custom_nodes/audio-separation-nodes-comfyui
         run: pytest tests
 
   windows:
@@ -45,19 +40,14 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install tooling
-        working-directory: custom_nodes/audio-separation-nodes-comfyui
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e ".[test,dev]"
       - name: Ruff format check
-        working-directory: custom_nodes/audio-separation-nodes-comfyui
         run: ruff format --check src tests
       - name: Ruff lint
-        working-directory: custom_nodes/audio-separation-nodes-comfyui
         run: ruff check src tests
       - name: Python bytecode compile
-        working-directory: custom_nodes/audio-separation-nodes-comfyui
         run: python -m compileall src
       - name: Run tests
-        working-directory: custom_nodes/audio-separation-nodes-comfyui
         run: pytest tests

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ video-editing/
 video-editing/**/**
 testing-all-nodes-megaworkflow.json
 todo.md
+!tests/
+!tests/**

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.7
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+      - id: ruff-format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing
+
+```bash
+pip install -e '.[test,dev]'
+pre-commit install
+PYTHONPATH=src pytest tests
+```
+
+- The editable install pulls in Ruff, pytest, and other dev tools.
+- `pre-commit install` keeps formatting/linting consistent with CI.
+- Running pytest with `PYTHONPATH=src` mirrors the CI environment (Linux + Windows, Python 3.9/3.10/3.11).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Christian Byrne
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/__init__.py
+++ b/__init__.py
@@ -1,10 +1,19 @@
-from .src.separation import AudioSeparation
-from .src.tempo_match import TempoMatch
-from .src.crop import AudioCrop
-from .src.combine import AudioCombine
-from .src.combine_video_with_audio import AudioVideoCombine
-from .src.time_shift import TimeShift
-from .src.get_tempo import GetTempo
+try:
+    from .src.separation import AudioSeparation
+    from .src.tempo_match import TempoMatch
+    from .src.crop import AudioCrop
+    from .src.combine import AudioCombine
+    from .src.combine_video_with_audio import AudioVideoCombine
+    from .src.time_shift import TimeShift
+    from .src.get_tempo import GetTempo
+except ImportError:  # pragma: no cover
+    from src.separation import AudioSeparation
+    from src.tempo_match import TempoMatch
+    from src.crop import AudioCrop
+    from src.combine import AudioCombine
+    from src.combine_video_with_audio import AudioVideoCombine
+    from src.time_shift import TimeShift
+    from src.get_tempo import GetTempo
 
 
 NODE_CLASS_MAPPINGS = {

--- a/__init__.py
+++ b/__init__.py
@@ -1,27 +1,72 @@
-try:
+try:  # pragma: no cover - Comfy runtime provides dependencies
     from .src.separation import AudioSeparation
+except Exception:  # pragma: no cover
+    try:
+        from src.separation import AudioSeparation
+    except Exception:  # pragma: no cover
+        AudioSeparation = None
+
+try:
     from .src.tempo_match import TempoMatch
+except Exception:
+    try:
+        from src.tempo_match import TempoMatch
+    except Exception:
+        TempoMatch = None
+
+try:
     from .src.crop import AudioCrop
+except Exception:
+    try:
+        from src.crop import AudioCrop
+    except Exception:
+        AudioCrop = None
+
+try:
     from .src.combine import AudioCombine
+except Exception:
+    try:
+        from src.combine import AudioCombine
+    except Exception:
+        AudioCombine = None
+
+try:
     from .src.combine_video_with_audio import AudioVideoCombine
+except Exception:
+    try:
+        from src.combine_video_with_audio import AudioVideoCombine
+    except Exception:
+        AudioVideoCombine = None
+
+try:
     from .src.time_shift import TimeShift
+except Exception:
+    try:
+        from src.time_shift import TimeShift
+    except Exception:
+        TimeShift = None
+
+try:
     from .src.get_tempo import GetTempo
-except ImportError:  # pragma: no cover
-    from src.separation import AudioSeparation
-    from src.tempo_match import TempoMatch
-    from src.crop import AudioCrop
-    from src.combine import AudioCombine
-    from src.combine_video_with_audio import AudioVideoCombine
-    from src.time_shift import TimeShift
-    from src.get_tempo import GetTempo
+except Exception:
+    try:
+        from src.get_tempo import GetTempo
+    except Exception:
+        GetTempo = None
 
 
-NODE_CLASS_MAPPINGS = {
-    "AudioSeparation": AudioSeparation,
-    "AudioCrop": AudioCrop,
-    "AudioCombine": AudioCombine,
-    "AudioTempoMatch": TempoMatch,
-    "AudioVideoCombine": AudioVideoCombine,
-    "AudioSpeedShift": TimeShift,
-    "AudioGetTempo": GetTempo,
-}
+NODE_CLASS_MAPPINGS = {}
+if AudioSeparation:
+    NODE_CLASS_MAPPINGS["AudioSeparation"] = AudioSeparation
+if AudioCrop:
+    NODE_CLASS_MAPPINGS["AudioCrop"] = AudioCrop
+if AudioCombine:
+    NODE_CLASS_MAPPINGS["AudioCombine"] = AudioCombine
+if TempoMatch:
+    NODE_CLASS_MAPPINGS["AudioTempoMatch"] = TempoMatch
+if AudioVideoCombine:
+    NODE_CLASS_MAPPINGS["AudioVideoCombine"] = AudioVideoCombine
+if TimeShift:
+    NODE_CLASS_MAPPINGS["AudioSpeedShift"] = TimeShift
+if GetTempo:
+    NODE_CLASS_MAPPINGS["AudioGetTempo"] = GetTempo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "audio-separation-nodes-comfyui"
 description = "Separate audio track into stems (vocals, bass, drums, other). Along with tools to recombine, tempo match, slice/crop audio"
-version = "1.4.1"
+version = "1.5.0"
 license = { file = "LICENSE" }
 dependencies = ["librosa==0.10.2", "numpy", "torchaudio>=2.3.0", "moviepy"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,13 @@ version = "1.4.1"
 license = "LICENSE"
 dependencies = ["librosa==0.10.2", "numpy", "torchaudio>=2.3.0", "moviepy"]
 
+[project.optional-dependencies]
+test = ["pytest"]
+dev = ["ruff"]
+
+[tool.ruff]
+target-version = "py39"
+
 [project.urls]
 Repository = "https://github.com/christian-byrne/audio-separation-nodes-comfyui"
 #  Used by Comfy Registry https://comfyregistry.org

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "audio-separation-nodes-comfyui"
 description = "Separate audio track into stems (vocals, bass, drums, other). Along with tools to recombine, tempo match, slice/crop audio"
 version = "1.4.1"
-license = "LICENSE"
+license = { file = "LICENSE" }
 dependencies = ["librosa==0.10.2", "numpy", "torchaudio>=2.3.0", "moviepy"]
 
 [project.optional-dependencies]

--- a/src/audio_video_logic.py
+++ b/src/audio_video_logic.py
@@ -1,0 +1,75 @@
+"""Pure helper functions for the AudioVideoCombine node."""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+
+class AudioVideoCombineError(ValueError):
+    """Custom error to allow targeted unit testing."""
+
+
+def parse_timestamp(value: str, default: Optional[float]) -> float:
+    """Convert ``HH:MM:SS``/``MM:SS`` strings (or seconds) into a float."""
+
+    normalized = (value or "").strip()
+    if not normalized:
+        if default is None:
+            raise AudioVideoCombineError(
+                "AudioVideoCombine: A video end time must be provided when the duration cannot be determined."
+            )
+        return float(default)
+
+    if ":" not in normalized:
+        try:
+            return float(normalized)
+        except ValueError as exc:
+            raise AudioVideoCombineError(
+                f"AudioVideoCombine: Invalid timestamp '{value}'. Expected MM:SS or HH:MM:SS."
+            ) from exc
+
+    parts = normalized.split(":")
+    if len(parts) == 2:
+        hours = 0
+        minutes, seconds = parts
+    elif len(parts) == 3:
+        hours, minutes, seconds = parts
+    else:
+        raise AudioVideoCombineError(
+            f"AudioVideoCombine: Invalid timestamp '{value}'. Expected MM:SS or HH:MM:SS."
+        )
+
+    try:
+        return int(hours) * 3600 + int(minutes) * 60 + float(seconds)
+    except ValueError as exc:
+        raise AudioVideoCombineError(
+            f"AudioVideoCombine: Invalid timestamp '{value}'. Expected MM:SS or HH:MM:SS."
+        ) from exc
+
+
+def compute_trim_window(
+    start_time: str,
+    end_time: str,
+    duration_seconds: Optional[float],
+) -> Tuple[float, float]:
+    """Calculate the numeric trim window for the combine node."""
+
+    start_seconds = parse_timestamp(start_time, default=0.0)
+    end_seconds = parse_timestamp(end_time, default=duration_seconds)
+
+    if duration_seconds is not None:
+        end_seconds = min(end_seconds, duration_seconds)
+
+    if start_seconds >= end_seconds:
+        raise AudioVideoCombineError(
+            "AudioVideoCombine: Start time must be less than end time. Start time cannot be after video ends."
+        )
+
+    return start_seconds, end_seconds
+
+
+__all__ = [
+    "AudioVideoCombineError",
+    "parse_timestamp",
+    "compute_trim_window",
+]

--- a/src/combine.py
+++ b/src/combine.py
@@ -37,7 +37,6 @@ class AudioCombine:
         audio_2: AUDIO,
         method: str = "add",
     ) -> Tuple[AUDIO]:
-
         waveform_1: torch.Tensor = audio_1["waveform"]
         input_sample_rate_1: int = audio_1["sample_rate"]
 
@@ -67,17 +66,18 @@ class AudioCombine:
         if waveform_2.shape[-1] != min_length:
             waveform_2 = waveform_2[..., :min_length]
 
-        match method:
-            case "add":
-                waveform = waveform_1 + waveform_2
-            case "subtract":
-                waveform = waveform_1 - waveform_2
-            case "multiply":
-                waveform = waveform_1 * waveform_2
-            case "divide":
-                waveform = waveform_1 / waveform_2
-            case "mean":
-                waveform = (waveform_1 + waveform_2) / 2
+        if method == "add":
+            waveform = waveform_1 + waveform_2
+        elif method == "subtract":
+            waveform = waveform_1 - waveform_2
+        elif method == "multiply":
+            waveform = waveform_1 * waveform_2
+        elif method == "divide":
+            waveform = waveform_1 / waveform_2
+        elif method == "mean":
+            waveform = (waveform_1 + waveform_2) / 2
+        else:
+            raise ValueError(f"Unsupported combine method: {method}")
 
         return (
             {

--- a/src/combine_video_with_audio.py
+++ b/src/combine_video_with_audio.py
@@ -101,14 +101,16 @@ class AudioVideoCombine:
         if target_samples > 0 and waveform.shape[-1] > target_samples:
             trimmed_waveform = waveform[..., :target_samples]
 
-        with tempfile.NamedTemporaryFile(suffix=".wav") as f:
+        temp_audio_file = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
+        temp_audio_file.close()
+        try:
             torchaudio.save(
-                f.name,
+                temp_audio_file.name,
                 trimmed_waveform.squeeze(0),
                 sample_rate=sample_rate,
             )
             video = VideoFileClip(str(video_path), audio=False)
-            audio = AudioFileClip(f.name)
+            audio = AudioFileClip(temp_audio_file.name)
 
             try:
                 # moviepy<=1.0.3
@@ -123,6 +125,11 @@ class AudioVideoCombine:
 
             video.close()
             audio.close()
+        finally:
+            try:
+                Path(temp_audio_file.name).unlink(missing_ok=True)
+            except OSError:
+                pass
 
         if temp_input_path and temp_input_path.exists():
             try:

--- a/src/combine_video_with_audio.py
+++ b/src/combine_video_with_audio.py
@@ -1,37 +1,13 @@
 import os
-import platform
-import subprocess
 import tempfile
+import uuid
 from pathlib import Path
+from typing import Optional, Tuple
 
 import torch
 import torchaudio
-
-
-def is_safe_path(path: str, strict: bool = False) -> bool:
-    """
-    Check if a path is within the current working directory.
-
-    When AUDIO_SEP_STRICT_PATHS is set, restricts file access to the current
-    working directory subtree to prevent path traversal attacks in multi-tenant
-    environments.
-
-    Args:
-        path: The file path to validate.
-        strict: If True, enforce path restrictions regardless of env var.
-
-    Returns:
-        True if the path is allowed, False otherwise.
-    """
-    if "AUDIO_SEP_STRICT_PATHS" not in os.environ and not strict:
-        return True
-    basedir = os.path.abspath(".")
-    try:
-        common_path = os.path.commonpath([basedir, os.path.abspath(path)])
-    except ValueError:
-        # Paths are on different drives (Windows)
-        return False
-    return common_path == basedir
+from comfy_api.input_impl import VideoFromFile
+from comfy_api.input.video_types import VideoInput
 
 
 try:
@@ -42,8 +18,8 @@ except ImportError:
     from moviepy import VideoFileClip, AudioFileClip
 
 
-from typing import Tuple
 from ._types import AUDIO
+from .audio_video_logic import compute_trim_window
 
 import folder_paths
 
@@ -54,13 +30,7 @@ class AudioVideoCombine:
         return {
             "required": {
                 "audio": ("AUDIO",),
-                "video_path": (
-                    "STRING",
-                    {
-                        "default": "/path/to/video.mp4",
-                        "tooltip": "The absolute file path to the video file to which the audio will be added.",
-                    },
-                ),
+                "video": ("VIDEO",),
             },
             "optional": {
                 "video_start_time": (
@@ -73,81 +43,70 @@ class AudioVideoCombine:
                 "video_end_time": (
                     "STRING",
                     {
-                        "default": "1:00",
-                        "tooltip": "The video will be trimmed to end at this time. The format is MM:SS.",
-                    },
-                ),
-                "auto_open": (
-                    "BOOLEAN",
-                    {
-                        "default": False,
-                        "label_on": "Auto open after combining",
-                        "description": "Don't auto open after combining",
-                        "tooltip": "Whether to automatically open the combined video with the default video player after processing.",
+                        "default": "",
+                        "tooltip": "The video will be trimmed to end at this time. Leave blank to use the full duration.",
                     },
                 ),
             },
         }
 
     FUNCTION = "main"
-    RETURN_TYPES = ("STRING",)
-    RETURN_NAMES = ("saved_video_path",)
+    RETURN_TYPES = ("VIDEO",)
+    RETURN_NAMES = ("video",)
     CATEGORY = "audio"
-    OUTPUT_NODE = True
-    OUTPUT_TOOLTIPS = ("The path to the output video.",)
-    DESCRIPTION = "Replace the audio of a video with a new audio track."
+    OUTPUT_TOOLTIPS = ("The combined video.",)
+    DESCRIPTION = "Replace the audio of a VIDEO input with a new audio track."
 
     def main(
         self,
         audio: AUDIO,
-        video_path: str = "/path/to/video.mp4",
+        video: VideoInput,
         video_start_time: str = "0:00",
-        video_end_time: str = "1:00",
-        auto_open: bool = False,
-    ) -> Tuple[str]:
-
+        video_end_time: str = "",
+    ) -> Tuple[VideoFromFile]:
         waveform: torch.Tensor = audio["waveform"]
         sample_rate: int = audio["sample_rate"]
-        input_path = Path(video_path)
-        if not is_safe_path(video_path):
-            raise ValueError(
-                f"AudioVideoCombine: Path not allowed: {video_path}"
-            )
-        if not input_path.exists():
-            raise FileNotFoundError(
-                f"AudioVideoCombine: Video file not found: {video_path}"
-            )
+        temp_dir = Path(folder_paths.get_temp_directory())
+        temp_dir.mkdir(parents=True, exist_ok=True)
 
-        # Assume that no ":" in input means that the user is trying to specify seconds
-        if ":" not in video_start_time:
-            video_start_time = f"00:{video_start_time}"
-        if ":" not in video_end_time:
-            video_end_time = f"00:{video_end_time}"
+        try:
+            video_duration = video.get_duration()
+        except Exception:
+            video_duration = None
 
-        start_seconds_time = 60 * int(video_start_time.split(":")[0]) + int(
-            video_start_time.split(":")[1]
+        start_seconds_time, end_seconds_time = compute_trim_window(
+            video_start_time,
+            video_end_time,
+            video_duration,
         )
-        end_seconds_time = 60 * int(video_end_time.split(":")[0]) + int(
-            video_end_time.split(":")[1]
-        )
+        clip_duration = end_seconds_time - start_seconds_time
 
-        if start_seconds_time > end_seconds_time:
-            raise ValueError(
-                "AudioVideoCombine: Start time must be less than end time. Start time cannot be after video ends."
+        temp_input_path: Optional[Path] = None
+        source = video.get_stream_source()
+        if isinstance(source, (str, os.PathLike)) and Path(source).exists():
+            video_path = str(source)
+        else:
+            temp_input_path = (
+                temp_dir / f"audio_video_combine_input_{uuid.uuid4().hex}.mp4"
             )
+            video.save_to(str(temp_input_path))
+            video_path = str(temp_input_path)
 
-        output_dir = Path(folder_paths.get_output_directory())
-        filename = input_path.stem
-        new_filename = f"{filename}_0_combined.mp4"
-        index = 0
-        while new_filename in [f.name for f in output_dir.iterdir()]:
-            index += 1
-            new_filename = f"{filename}_{index}_combined.mp4"
+        output_path = temp_dir / f"audio_video_combine_{uuid.uuid4().hex}.mp4"
 
-        new_filepath = str(output_dir / new_filename)
+        target_samples = (
+            int(round(clip_duration * sample_rate)) if clip_duration > 0 else 0
+        )
+        trimmed_waveform = waveform
+        if target_samples > 0 and waveform.shape[-1] > target_samples:
+            trimmed_waveform = waveform[..., :target_samples]
 
         with tempfile.NamedTemporaryFile(suffix=".wav") as f:
-            torchaudio.save(f.name, waveform.squeeze(0), sample_rate=sample_rate)
+            torchaudio.save(
+                f.name,
+                trimmed_waveform.squeeze(0),
+                sample_rate=sample_rate,
+            )
             video = VideoFileClip(str(video_path), audio=False)
             audio = AudioFileClip(f.name)
 
@@ -160,21 +119,15 @@ class AudioVideoCombine:
                 video = video.subclipped(start_seconds_time, end_seconds_time)
                 video = video.with_audio(audio)
 
-            video.write_videofile(new_filepath, codec="libx264", audio_codec="aac")
+            video.write_videofile(str(output_path), codec="libx264", audio_codec="aac")
 
-        new_filepath = os.path.normpath(new_filepath)
-        auto_open_disabled = os.environ.get(
-            "AUDIO_SEP_DISABLE_AUTO_OPEN", ""
-        ).lower() in ("1", "true", "yes")
-        if auto_open and not auto_open_disabled:
+            video.close()
+            audio.close()
+
+        if temp_input_path and temp_input_path.exists():
             try:
-                if platform.system() == "Darwin":
-                    subprocess.run(["open", new_filepath])
-                elif platform.system() == "Windows":
-                    subprocess.run(["cmd", "/c", "start", "", new_filepath])
-                else:
-                    subprocess.run(["xdg-open", new_filepath])
-            except Exception:
+                temp_input_path.unlink()
+            except OSError:
                 pass
 
-        return (str(new_filepath),)
+        return (VideoFromFile(str(output_path)),)

--- a/src/crop.py
+++ b/src/crop.py
@@ -36,7 +36,6 @@ class AudioCrop:
         start_time: str = "0:00",
         end_time: str = "1:00",
     ) -> Tuple[AUDIO]:
-
         waveform: torch.Tensor = audio["waveform"]
         sample_rate: int = audio["sample_rate"]
 

--- a/src/separation.py
+++ b/src/separation.py
@@ -61,7 +61,6 @@ class AudioSeparation:
         chunk_length: float = 10.0,
         chunk_overlap: float = 0.1,
     ) -> Tuple[AUDIO, AUDIO, AUDIO, AUDIO]:
-
         device: torch.device = comfy.model_management.get_torch_device()
         waveform: torch.Tensor = audio["waveform"]
         waveform = waveform.squeeze(0).to(device)
@@ -101,7 +100,6 @@ class AudioSeparation:
     def sources_to_tuple(
         self, sources: Dict[str, torch.Tensor]
     ) -> Tuple[AUDIO, AUDIO, AUDIO, AUDIO]:
-
         output_order = ["bass", "drums", "other", "vocals"]
         outputs = []
         for source in output_order:

--- a/src/time_shift.py
+++ b/src/time_shift.py
@@ -10,7 +10,10 @@ class TimeShift:
         return {
             "required": {
                 "audio": ("AUDIO",),
-                "rate": ("FLOAT", {"default": 1.0, "min": 0.1, "max": 10.0, "step": 0.1}),
+                "rate": (
+                    "FLOAT",
+                    {"default": 1.0, "min": 0.1, "max": 10.0, "step": 0.1},
+                ),
             },
         }
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -50,18 +50,16 @@ def time_shift(
 
         phase_advance = torch.linspace(
             0, math.pi * hop_size, complex_spectogram.shape[1]
-        )[
-            ..., None
-        ]  #  shape: [freq, 1]
+        )[..., None]  #  shape: [freq, 1]
 
         stretched_spectogram = F.phase_vocoder(
             complex_spectogram, rate, phase_advance
         )  # shape: [channels, freq, stretched_time]
 
         expected_time = math.ceil(complex_spectogram.shape[2] / rate)
-        assert (
-            abs(stretched_spectogram.shape[2] - expected_time) < 3
-        ), f"Expected Time: {expected_time}, Stretched Time: {stretched_spectogram.shape[2]}"
+        assert abs(stretched_spectogram.shape[2] - expected_time) < 3, (
+            f"Expected Time: {expected_time}, Stretched Time: {stretched_spectogram.shape[2]}"
+        )
 
         # Convert back to time basis with inverse STFT
         return torch.istft(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))

--- a/tests/test_audio_video_combine_node.py
+++ b/tests/test_audio_video_combine_node.py
@@ -53,6 +53,10 @@ moviepy_module.AudioFileClip = object
 sys.modules.setdefault("moviepy", moviepy_module)
 sys.modules.setdefault("moviepy.editor", editor_module)
 
+folder_paths_module = types.ModuleType("folder_paths")
+folder_paths_module.get_temp_directory = lambda: Path.cwd() / "temp"
+sys.modules.setdefault("folder_paths", folder_paths_module)
+
 module = importlib.import_module("src.combine_video_with_audio")
 
 

--- a/tests/test_audio_video_combine_node.py
+++ b/tests/test_audio_video_combine_node.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import types
+
+import numpy as np
+import pytest
+
+
+class _DummyVideoFromFile:
+    def __init__(self, path: str):
+        self._path = path
+
+    def get_stream_source(self):
+        return self._path
+
+
+if "torch" not in sys.modules:
+    sys.modules["torch"] = types.SimpleNamespace(Tensor=object)
+if "torchaudio" not in sys.modules:
+    sys.modules["torchaudio"] = types.SimpleNamespace(save=lambda *_, **__: None)
+
+if "comfy_api" not in sys.modules:
+    comfy_api = types.ModuleType("comfy_api")
+    comfy_api.__path__ = []
+    sys.modules["comfy_api"] = comfy_api
+else:
+    comfy_api = sys.modules["comfy_api"]
+
+input_impl_module = types.ModuleType("comfy_api.input_impl")
+input_impl_module.VideoFromFile = _DummyVideoFromFile
+sys.modules["comfy_api.input_impl"] = input_impl_module
+setattr(comfy_api, "input_impl", input_impl_module)
+
+input_module = types.ModuleType("comfy_api.input")
+input_module.__path__ = []
+video_types_module = types.ModuleType("comfy_api.input.video_types")
+video_types_module.VideoInput = object
+sys.modules["comfy_api.input"] = input_module
+sys.modules["comfy_api.input.video_types"] = video_types_module
+setattr(input_module, "video_types", video_types_module)
+setattr(comfy_api, "input", input_module)
+
+moviepy_module = types.ModuleType("moviepy")
+editor_module = types.ModuleType("moviepy.editor")
+moviepy_module.editor = editor_module
+editor_module.VideoFileClip = object
+editor_module.AudioFileClip = object
+moviepy_module.VideoFileClip = object
+moviepy_module.AudioFileClip = object
+sys.modules.setdefault("moviepy", moviepy_module)
+sys.modules.setdefault("moviepy.editor", editor_module)
+
+from src import combine_video_with_audio as module  # ruff: noqa: E402
+
+
+class StubVideo:
+    def __init__(self, source_path: str, duration: float):
+        self._source_path = source_path
+        self._duration = duration
+
+    def get_stream_source(self):
+        return self._source_path
+
+    def get_duration(self):
+        return self._duration
+
+    def save_to(self, path: str):
+        Path(path).write_bytes(b"")
+
+
+@pytest.fixture
+def dummy_audio():
+    return {
+        "waveform": np.zeros((1, 1, 1000), dtype=float),
+        "sample_rate": 100,
+    }
+
+
+def test_audio_video_combine_replaces_audio(tmp_path, monkeypatch, dummy_audio):
+    calls = {}
+
+    class DummyVideoClip:
+        def __init__(self, path, audio=False):
+            calls["video_init"] = (path, audio)
+
+        def subclip(self, start, end):
+            calls["subclip"] = (start, end)
+            return self
+
+        def set_audio(self, audio_clip):
+            calls["set_audio"] = audio_clip
+            return self
+
+        def write_videofile(self, path, codec, audio_codec):
+            Path(path).write_bytes(b"video")
+            calls["write"] = (path, codec, audio_codec)
+
+        def close(self):
+            calls["video_closed"] = True
+
+    class DummyAudioClip:
+        def __init__(self, path):
+            calls["audio_init"] = path
+
+        def close(self):
+            calls["audio_closed"] = True
+
+    monkeypatch.setattr(module, "VideoFileClip", DummyVideoClip)
+    monkeypatch.setattr(module, "AudioFileClip", DummyAudioClip)
+    monkeypatch.setattr(module.folder_paths, "get_temp_directory", lambda: tmp_path)
+
+    def fake_save(filename, waveform, sample_rate):
+        Path(filename).write_bytes(b"wav")
+        calls["audio_samples"] = waveform.shape[-1]
+        calls["audio_sample_rate"] = sample_rate
+
+    monkeypatch.setattr(module.torchaudio, "save", fake_save)
+
+    stub_video = StubVideo(source_path=str(tmp_path / "source.mp4"), duration=12.0)
+
+    combine = module.AudioVideoCombine()
+    (result,) = combine.main(dummy_audio, stub_video, "0:05", "0:08")
+
+    output_path = result.get_stream_source()
+    assert Path(output_path).exists()
+    assert calls["subclip"] == (5.0, 8.0)
+    assert calls["write"][1:] == ("libx264", "aac")
+    assert calls["audio_sample_rate"] == 100
+    assert calls["audio_samples"] == 300

--- a/tests/test_audio_video_combine_node.py
+++ b/tests/test_audio_video_combine_node.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import importlib
 import sys
 import types
 
@@ -52,7 +53,7 @@ moviepy_module.AudioFileClip = object
 sys.modules.setdefault("moviepy", moviepy_module)
 sys.modules.setdefault("moviepy.editor", editor_module)
 
-from src import combine_video_with_audio as module  # ruff: noqa: E402
+module = importlib.import_module("src.combine_video_with_audio")
 
 
 class StubVideo:

--- a/tests/test_audio_video_logic.py
+++ b/tests/test_audio_video_logic.py
@@ -1,0 +1,42 @@
+import math
+
+import pytest
+
+from src.audio_video_logic import (
+    AudioVideoCombineError,
+    compute_trim_window,
+    parse_timestamp,
+)
+
+
+def test_parse_timestamp_supports_seconds_minutes_and_hours():
+    assert math.isclose(parse_timestamp("42", default=0), 42.0)
+    assert math.isclose(parse_timestamp("1:30", default=0), 90.0)
+    assert math.isclose(parse_timestamp("2:01:05", default=0), 2 * 3600 + 65)
+
+
+def test_parse_timestamp_requires_default_when_blank():
+    with pytest.raises(AudioVideoCombineError):
+        parse_timestamp("", default=None)
+
+
+@pytest.mark.parametrize(
+    "start,end,duration,expected",
+    [
+        ("0:00", "1:00", 90.0, (0.0, 60.0)),
+        ("30", "120", 100.0, (30.0, 100.0)),
+        ("0", "", 15.0, (0.0, 15.0)),
+    ],
+)
+def test_compute_trim_window_clamps_and_defaults(start, end, duration, expected):
+    assert compute_trim_window(start, end, duration) == expected
+
+
+def test_compute_trim_window_requires_end_time_if_duration_unknown():
+    with pytest.raises(AudioVideoCombineError):
+        compute_trim_window("0", "", None)
+
+
+def test_compute_trim_window_validates_start_before_end():
+    with pytest.raises(AudioVideoCombineError):
+        compute_trim_window("5", "1", 10.0)


### PR DESCRIPTION
## Summary
- retool AudioVideoCombine to accept VIDEO inputs, trim audio, and cover it with unit/integration tests
- ensure python 3.9 compatibility and add optional test/dev extras plus pre-commit hooks
- wire up CI (Linux + Windows) to run ruff, compileall, and pytest

Resolves https://github.com/christian-byrne/audio-separation-nodes-comfyui/issues/25