### PR TITLE
fix: Phase 2 issue triage — corrupted model error (#21), stem docs (#11), troubleshooting (#9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,25 @@ https://github.com/user-attachments/assets/c5cf20de-a17f-438d-81ac-0c392af669cf
 
 &nbsp;
 
+# Stem Mapping
+
+The **Audio Separation** node uses [Hybrid Demucs](https://pytorch.org/audio/stable/tutorials/hybrid_demucs_tutorial.html) to split audio into four stems:
+
+| Output | Contains |
+|--------|----------|
+| **Bass** | Bass guitar, sub-bass, low-frequency instruments |
+| **Drums** | Drums, percussion, hi-hats |
+| **Other** | Everything else — guitars, keyboards, synths, strings, etc. |
+| **Vocals** | Singing, speech, vocal harmonies |
+
+> **Looking for a specific instrument like guitar?** Guitar is included in the
+> **Other** stem. To isolate guitar, separate first, then use the **Audio Combine**
+> node to subtract unwanted elements or further process the "Other" output.
+
 # Requirements
 
-```m
-librosa==0.10.2
+```
+librosa>=0.10.2,<1
 torchaudio>=2.3.0
 numpy
 moviepy
@@ -89,3 +104,37 @@ moviepy
 1. `git clone` this repository in `ComfyUI/custom_nodes` folder
 1. `cd` into the cloned repository
 1. `pip install -r requirements.txt`
+
+# Troubleshooting
+
+<details>
+<summary><b>BadZipFile / "failed finding central directory"</b></summary>
+
+This error means the Hybrid Demucs model checkpoint was corrupted during download.
+Delete the cached file and restart ComfyUI to trigger a fresh download:
+
+```bash
+# Default location (Linux/macOS)
+rm ~/.cache/torch/hub/checkpoints/*.th
+
+# Windows
+del %USERPROFILE%\.cache\torch\hub\checkpoints\*.th
+```
+
+See [#21](https://github.com/christian-byrne/audio-separation-nodes-comfyui/issues/21).
+
+</details>
+
+<details>
+<summary><b>ConnectionResetError on Windows</b></summary>
+
+```
+Exception in callback _ProactorBasePipeTransport._call_connection_lost(None)
+ConnectionResetError: [WinError 10054]
+```
+
+This is harmless Windows asyncio noise — it does not affect audio separation results.
+The error comes from Python's `ProactorEventLoop` closing connections and can be
+safely ignored. See [#9](https://github.com/christian-byrne/audio-separation-nodes-comfyui/issues/9).
+
+</details>

--- a/src/separation.py
+++ b/src/separation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from zipfile import BadZipFile
 
 import comfy.model_management
 import torch
@@ -71,7 +72,16 @@ class AudioSeparation:
         self.input_sample_rate_: int = audio["sample_rate"]
 
         bundle = HDEMUCS_HIGH_MUSDB_PLUS
-        model: torch.nn.Module = bundle.get_model().to(device)
+        try:
+            model: torch.nn.Module = bundle.get_model()
+        except (BadZipFile, RuntimeError) as exc:
+            raise RuntimeError(
+                "Failed to load the Hybrid Demucs model — the downloaded checkpoint "
+                "appears to be corrupted. Delete the cached model file and restart "
+                "ComfyUI to trigger a fresh download. The cached file is typically "
+                "located in your torch hub cache directory (~/.cache/torch/hub/checkpoints/)."
+            ) from exc
+        model = model.to(device)
         self.model_sample_rate = bundle.sample_rate
 
         waveform = ensure_stereo(waveform)

--- a/tests/test_separation.py
+++ b/tests/test_separation.py
@@ -4,6 +4,7 @@ import importlib
 import sys
 import types
 from unittest.mock import MagicMock, patch
+from zipfile import BadZipFile
 
 import numpy as np
 import pytest
@@ -589,3 +590,66 @@ class TestMainFlow:
         result = self.node.main(audio)
         for r in result:
             assert r["sample_rate"] == _MODEL_SR
+
+
+# ===========================================================================
+# 6. Corrupted model checkpoint handling (#21)
+# ===========================================================================
+
+
+class TestCorruptedModelCheckpoint:
+    def setup_method(self):
+        self.node = AudioSeparation()
+
+    def test_bad_zip_file_raises_runtime_error(self, monkeypatch):
+        """BadZipFile from corrupted checkpoint should be wrapped with a helpful message."""
+        bad_bundle = types.SimpleNamespace(
+            get_model=MagicMock(side_effect=BadZipFile("failed finding central directory")),
+            sample_rate=_MODEL_SR,
+        )
+        monkeypatch.setattr(separation, "HDEMUCS_HIGH_MUSDB_PLUS", bad_bundle)
+
+        audio = _make_audio(channels=2, frames=44100, sample_rate=_MODEL_SR)
+        with pytest.raises(RuntimeError, match="corrupted"):
+            self.node.main(audio)
+
+    def test_runtime_error_from_model_load_wrapped(self, monkeypatch):
+        """RuntimeError during model load should also produce a helpful message."""
+        bad_bundle = types.SimpleNamespace(
+            get_model=MagicMock(side_effect=RuntimeError("invalid load key")),
+            sample_rate=_MODEL_SR,
+        )
+        monkeypatch.setattr(separation, "HDEMUCS_HIGH_MUSDB_PLUS", bad_bundle)
+
+        audio = _make_audio(channels=2, frames=44100, sample_rate=_MODEL_SR)
+        with pytest.raises(RuntimeError, match="Delete the cached model file"):
+            self.node.main(audio)
+
+    def test_corrupted_error_preserves_original_cause(self, monkeypatch):
+        """The original exception should be chained via __cause__."""
+        original = BadZipFile("bad archive")
+        bad_bundle = types.SimpleNamespace(
+            get_model=MagicMock(side_effect=original),
+            sample_rate=_MODEL_SR,
+        )
+        monkeypatch.setattr(separation, "HDEMUCS_HIGH_MUSDB_PLUS", bad_bundle)
+
+        audio = _make_audio(channels=2, frames=44100, sample_rate=_MODEL_SR)
+        with pytest.raises(RuntimeError) as exc_info:
+            self.node.main(audio)
+        assert exc_info.value.__cause__ is original
+
+    def test_to_device_error_not_wrapped(self, monkeypatch):
+        """RuntimeError from .to(device) (e.g. CUDA OOM) should NOT be wrapped as 'corrupted'."""
+        model = _MockModel()
+        model.to = MagicMock(side_effect=RuntimeError("CUDA out of memory"))
+
+        good_bundle = types.SimpleNamespace(
+            get_model=MagicMock(return_value=model),
+            sample_rate=_MODEL_SR,
+        )
+        monkeypatch.setattr(separation, "HDEMUCS_HIGH_MUSDB_PLUS", good_bundle)
+
+        audio = _make_audio(channels=2, frames=44100, sample_rate=_MODEL_SR)
+        with pytest.raises(RuntimeError, match="CUDA out of memory"):
+            self.node.main(audio)


### PR DESCRIPTION
## Phase 2: Issue Triage

Addresses three open issues identified during v2 triage:

### Issue #21 — `BadZipFile` / corrupted model checkpoint
- Wraps `bundle.get_model()` with `try/except` for `BadZipFile` and `RuntimeError`
- Raises a clear `RuntimeError` telling users to delete the cached checkpoint and re-download
- Chains original exception via `raise ... from exc` for debugging
- 3 new tests covering both exception types and cause chaining

### Issue #11 — Guitar track extraction
- Added **Stem Mapping** section to README documenting which instruments go to which output
- Explicitly notes guitar → "Other" stem with guidance on further isolation

### Issue #9 — ConnectionResetError on Windows
- Added **Troubleshooting** section to README explaining this is harmless Windows asyncio noise

### Also
- Fixed outdated `librosa==0.10.2` in README to match actual `>=0.10.2,<1` pin

### Tests
- 169 tests pass, 94% coverage
- Lint clean (ruff check + format)

Closes #9, closes #11, closes #21