### PR TITLE
chore: repo essentials — metadata, tooling, and badges

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,61 @@
+name: Bug Report
+description: Report a bug with Audio Separation Nodes
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please fill out the sections below.
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce this issue?
+      placeholder: |
+        1. Load workflow with ...
+        2. Connect nodes ...
+        3. Execute ...
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened? Include error messages or logs if applicable.
+    validations:
+      required: true
+  - type: input
+    id: comfyui-version
+    attributes:
+      label: ComfyUI version
+      placeholder: "e.g., latest, commit hash, or release tag"
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: "e.g., Windows 11, Ubuntu 24.04, macOS 15"
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      placeholder: "e.g., 3.11.9"
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Any other context, screenshots, or workflow files.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement!
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this feature solve?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe the solution you'd like.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any alternative approaches you've considered.
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Any other context, mockups, or examples.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Summary
+
+<!-- Brief description of what this PR does -->
+
+## Related issues
+
+<!-- Link issues: Closes #N, Fixes #N -->
+
+## Changes
+
+- 
+
+## Checklist
+
+- [ ] Tests pass locally (`pytest tests`)
+- [ ] Linting passes (`ruff check src tests`)
+- [ ] Formatting passes (`ruff format --check src tests`)
+- [ ] New code has test coverage

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,18 @@
+changelog:
+  categories:
+    - title: "🚀 Features"
+      labels:
+        - enhancement
+    - title: "🐛 Bug Fixes"
+      labels:
+        - bug
+    - title: "🧹 Maintenance"
+      labels:
+        - chore
+        - dependencies
+    - title: "📖 Documentation"
+      labels:
+        - documentation
+    - title: "Other Changes"
+      labels:
+        - "*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.0.0] - 2025-04-13
+
+### Added
+
+- Comprehensive test suite with 187 tests and 95% coverage ([#30])
+- Ruff linting and formatting with CI enforcement ([#30])
+- Windows CI testing on Python 3.10 ([#30])
+- Configurable `tolerance` and `clamp` parameters for ChunkResampler ([#34])
+- Nodes table in README documenting all seven nodes ([#33])
+- Stem mapping reference and troubleshooting guide in README ([#32])
+
+### Fixed
+
+- CPU device handling no longer silently skips separation ([#31], [#23])
+- Float-to-int cast errors in audio processing ([#31], [#16], [#22])
+- Corrupted model checkpoint error with actionable fix instructions ([#32], [#21])
+
+### Changed
+
+- Pinned librosa to `>=0.10.2,<1` to prevent breaking changes ([#31], [#20])
+- Version bumped from 1.x to 2.0.0 ([#33])
+
+[2.0.0]: https://github.com/christian-byrne/audio-separation-nodes-comfyui/releases/tag/v2.0.0
+[#4]: https://github.com/christian-byrne/audio-separation-nodes-comfyui/issues/4
+[#9]: https://github.com/christian-byrne/audio-separation-nodes-comfyui/issues/9
+[#11]: https://github.com/christian-byrne/audio-separation-nodes-comfyui/issues/11
+[#16]: https://github.com/christian-byrne/audio-separation-nodes-comfyui/issues/16
+[#20]: https://github.com/christian-byrne/audio-separation-nodes-comfyui/issues/20
+[#21]: https://github.com/christian-byrne/audio-separation-nodes-comfyui/issues/21
+[#22]: https://github.com/christian-byrne/audio-separation-nodes-comfyui/issues/22
+[#23]: https://github.com/christian-byrne/audio-separation-nodes-comfyui/issues/23
+[#30]: https://github.com/christian-byrne/audio-separation-nodes-comfyui/pull/30
+[#31]: https://github.com/christian-byrne/audio-separation-nodes-comfyui/pull/31
+[#32]: https://github.com/christian-byrne/audio-separation-nodes-comfyui/pull/32
+[#33]: https://github.com/christian-byrne/audio-separation-nodes-comfyui/pull/33
+[#34]: https://github.com/christian-byrne/audio-separation-nodes-comfyui/pull/34
+[#35]: https://github.com/christian-byrne/audio-separation-nodes-comfyui/pull/35

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it
+responsibly:
+
+1. **Do not** open a public GitHub issue.
+2. Email **christian.byrne@comfy.org** with:
+   - A description of the vulnerability
+   - Steps to reproduce
+   - Potential impact
+3. You will receive a response within 7 days.
+
+## Scope
+
+This project is a set of ComfyUI custom nodes for audio separation. Security
+concerns most likely involve:
+
+- Arbitrary code execution via crafted audio files
+- Path traversal in file handling
+- Denial of service through resource exhaustion
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| 2.x     | ✅         |
+| < 2.0   | ❌         |


### PR DESCRIPTION
Repo quality improvements:

- Add `requires-python = ">=3.9"` to pyproject.toml (#50)
- Update pre-commit ruff rev from v0.5.7 to v0.14.0 (#52)
- Add `.git-blame-ignore-revs` for Phase 0 formatting commit (#45)
- Add `.editorconfig` for consistent editor settings (#51)
- Add CI, Python, and License badges to README (#49)

Closes #50
Closes #52
Closes #45
Closes #51
Closes #49

Part of #38