### PR TITLE
ci: add concurrency, permissions, pip caching, and timeouts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,9 +5,17 @@ on:
     branches: ["master"]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
         matrix:
           python-version: ["3.9", "3.10", "3.11"]
@@ -16,6 +24,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
       - name: Install tooling
         run: |
           python -m pip install --upgrade pip
@@ -31,6 +40,7 @@ jobs:
 
   windows:
     runs-on: windows-latest
+    timeout-minutes: 10
     strategy:
       matrix:
         python-version: ["3.10"]
@@ -39,6 +49,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
       - name: Install tooling
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
Harden CI workflow:

- Add concurrency group to cancel superseded runs (#39)
- Add explicit `permissions: contents: read` for least-privilege (#40)
- Enable pip dependency caching on both jobs (#41)
- Add `timeout-minutes: 10` to prevent runaway jobs (#42)

Closes #39
Closes #40
Closes #41
Closes #42

Part of #38